### PR TITLE
Added compatibility for QS1A inverter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This integration queries the local ECU-R every 1 minute for new data. This was d
 This couldn't have been done without the hardwork of @checking12 and @HAEdwin on the home assistant forum, and all the other people from this forum (https://gathering.tweakers.net/forum/list_messages/2032302/1)
 
 ## Prerequisites
-You own an APSystems ECU-R and any combination of YC600, YC1000 or QS1 inverter.
+You own an APSystems ECU-R and any combination of YC600, YC1000 or QS1/QS1A inverter.
 This component only works if the ECU-R is attached to your network by Wifi. To enable and configure WiFi on the ECU-R, use the ECUapp (downloadable via Appstore or Google Play) and temporarily enable the ECU-R's accesspoint by pressing the button on the side of the ECU-R. Then connect your phone's WiFi to the ECU-R's accesspoint to enable the ECUapp to connect and configure the ECU-R.
 Although there's no need to also attach the ECU-R by ethernet cable, you are free to do so if you like.
 ```
@@ -16,6 +16,7 @@ Although there's no need to also attach the ECU-R by ethernet cable, you are fre
 Release notes
 v1.0.0 First release
 v1.0.1 Revised the readme, added support for YC1000 and added versioning to the manifest
+v1.0.2 Added support for QS1A
 ```
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # homeassistant-apsystems_ecur
-This is a custom component for [Home Assistant](http://home-assistant.io) that adds support for the APSystems ECU-R solar Energy Communication Unit [APsystems](http://www.apsystems.com). With this component you are able to monitor your PV installation (inverters) in detail.
+This is a custom component for [Home Assistant](http://home-assistant.io) that adds support for the [APsystems](http://www.apsystems.com) ECU-R solar Energy Communication Unit. With this component you are able to monitor your PV installation (inverters) in detail.
 
 
 ## Background & acknowledgement
@@ -15,7 +15,7 @@ Although there's no need to also attach the ECU-R by ethernet cable, you are fre
 
 Release notes
 v1.0.0 First release
-v1.0.1 Revised the readme, added support for YC1000 (hopefully) and added versioning to the manifest
+v1.0.1 Revised the readme, added support for YC1000 and added versioning to the manifest
 ```
 
 ## Setup

--- a/custom_components/apsystems_ecur/APSystemsECUR.py
+++ b/custom_components/apsystems_ecur/APSystemsECUR.py
@@ -32,7 +32,7 @@ class APSystemsECUR:
         # how big of a buffer to read at a time from the socket
         self.recv_size = 4096
 
-        self.qs1_ids = [ "802", "801" ]
+        self.qs1_ids = [ "802", "801", "804" ]
         self.yc600_ids = [ "406", "407", "408", "409" ]
         self.yc1000_ids = [ "501", "502", "503", "504" ]
 

--- a/custom_components/apsystems_ecur/manifest.json
+++ b/custom_components/apsystems_ecur/manifest.json
@@ -5,6 +5,6 @@
   "documentation": "https://github.com/ksheumaker/homeassistant-apsystems_ecur",
   "domain": "apsystems_ecur",
   "name": "APSystems PV solar ECU-R",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "requirements": []
 }


### PR DESCRIPTION
QS1A inverters start with ID 804 and uses the same protocol like the QS1.