### PR TITLE
Update sensor.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,15 @@ v1.0.1 Revised the readme, added support for YC1000 and added versioning to the 
 v1.0.2 Added support for QS1A
 v1.0.3 Added support for 2021.8.0 (including energy panel), fixed some issues with ECU_R_PRO
 v1.0.4 Added optional scan_interval to config
+v1.0.5 Fixed energy dashboard and added HACS setup option description in readme.md
 ```
 
 ## Setup
-Copy contents of the apsystems_ecur/ directory into your <HA-CONFIG>/custom_components/apsystems_ecur directory (```/config/custom_components``` on hassio)
+Option 1:
+Easiest option, install the custom component using HACS by searching for "APSystems ECU-R"
 
+Option 2:
+Copy contents of the apsystems_ecur/ directory into your <HA-CONFIG>/custom_components/apsystems_ecur directory (```/config/custom_components``` on hassio)
 Your directory structure should look like this:
 ```
    config/custom_components/apsystems_ecur/__init__.py

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # homeassistant-apsystems_ecur
-This is a custom component for [Home Assistant](http://home-assistant.io) that adds support for the [APsystems](http://www.apsystems.com) ECU-R solar Energy Communication Unit. With this component you are able to monitor your PV installation (inverters) in detail.
+This is a custom component for [Home Assistant](http://home-assistant.io) that adds support for the [APsystems](http://www.apsystems.com) ECU-R and ECU-B solar Energy Communication Unit. With this component you are able to monitor your PV installation (inverters) in detail.
 
 
 ## Background & acknowledgement
-This integration queries the local ECU-R every 1 minute for new data. This was done without a public API, and by listening to and interpreting the protocol the APSystems ECU phone app (ECUapp) uses when setting up the PV array.
+This integration queries the local ECU-R and ECU-B every 1 minute for new data. This was done without a public API, and by listening to and interpreting the protocol the APSystems ECU phone app (ECUapp) uses when setting up the PV array.
 
 This couldn't have been done without the hardwork of @checking12 and @HAEdwin on the home assistant forum, and all the other people from this forum (https://gathering.tweakers.net/forum/list_messages/2032302/1)
 
 ## Prerequisites
-You own an APSystems ECU-R and any combination of YC600, YC1000 or QS1/QS1A inverter.
-This component only works if the ECU-R is attached to your network by Wifi. To enable and configure WiFi on the ECU-R, use the ECUapp (downloadable via Appstore or Google Play) and temporarily enable the ECU-R's accesspoint by pressing the button on the side of the ECU-R. Then connect your phone's WiFi to the ECU-R's accesspoint to enable the ECUapp to connect and configure the ECU-R.
-Although there's no need to also attach the ECU-R by ethernet cable, you are free to do so if you like.
+You own an APSystems ECU-R or ECU-B and any combination of YC600, YC1000 or QS1/QS1A inverter.
+This component only works if the ECU-R or ECU-B is attached to your network by Wifi. To enable and configure WiFi on the ECU, use the ECUapp (downloadable via Appstore or Google Play) and temporarily enable the ECU's accesspoint by pressing the button on the side of the ECU. Then connect your phone's WiFi to the ECU's accesspoint to enable the ECUapp to connect and configure the ECU.
+Although there's no need to also attach the ECU-R by ethernet cable (for the ECU-B LAN ports are disabled), you are free to do so if you like.
 ```
 
 Release notes
@@ -20,6 +20,7 @@ v1.0.2 Added support for QS1A
 v1.0.3 Added support for 2021.8.0 (including energy panel), fixed some issues with ECU_R_PRO
 v1.0.4 Added optional scan_interval to config
 v1.0.5 Fixed energy dashboard and added HACS setup option description in readme.md
+v1.0.6 Replaces deprecated device_state_attributes for extra_state_attributes and mentioned the ECU-B because of compatibility with this component
 ```
 
 ## Setup
@@ -31,14 +32,16 @@ Copy contents of the apsystems_ecur/ directory into your <HA-CONFIG>/custom_comp
 Your directory structure should look like this:
 ```
    config/custom_components/apsystems_ecur/__init__.py
+   config/custom_components/apsystems_ecur/APSystemsECUR.py
+   config/custom_components/apsystems_ecur/binary_sensor.py
    config/custom_components/apsystems_ecur/const.py
-   config/custom_components/apsystems_ecur/sensor.py
-   config/custom_components/apsystems_ecur/APSysstemsECUR.py
    config/custom_components/apsystems_ecur/manifest.json
+   config/custom_components/apsystems_ecur/sensor.py
+   config/custom_components/apsystems_ecur/services.yaml
 ```
 
 ## Configuration
-Add the following snippet into your ```configuration.yaml```  replace [IPADDR] with the WiFi connected IP address of your ECU-R device. By default the integration will query the ECU every 60 seconds, you can alter this by altering the scan interval configuration option.  
+Add the following snippet into your ```configuration.yaml```  replace [IPADDR] with the WiFi connected IP address of your ECU-R or ECU-B device. By default the integration will query the ECU every 60 seconds, you can alter this by altering the scan interval configuration option.  
 
 _Warning_ the ECU device isn't the most powerful querying it more frequently could lead to stability issues with the ECU and require a power cycle.
 

--- a/custom_components/apsystems_ecur/binary_sensor.py
+++ b/custom_components/apsystems_ecur/binary_sensor.py
@@ -74,7 +74,7 @@ class APSystemsECUBinarySensor(CoordinatorEntity, BinarySensorEntity):
         return self._icon
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
 
         attrs = {
             "ecu_id" : self._ecu.ecu.ecu_id,

--- a/custom_components/apsystems_ecur/sensor.py
+++ b/custom_components/apsystems_ecur/sensor.py
@@ -145,7 +145,7 @@ class APSystemsECUInverterSensor(CoordinatorEntity, SensorEntity):
 
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
 
         attrs = {
             "ecu_id" : self._ecu.ecu.ecu_id,
@@ -202,7 +202,7 @@ class APSystemsECUSensor(CoordinatorEntity, SensorEntity):
         return self._unit
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
 
         attrs = {
             "ecu_id" : self._ecu.ecu.ecu_id,

--- a/custom_components/apsystems_ecur/sensor.py
+++ b/custom_components/apsystems_ecur/sensor.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.update_coordinator import (
 
 from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING
 )
 
 from .const import (
@@ -56,7 +57,7 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
             devclass=DEVICE_CLASS_ENERGY, icon=SOLAR_ICON),
         APSystemsECUSensor(coordinator, ecu, "lifetime_energy", 
             label="Lifetime Energy", unit=ENERGY_KILO_WATT_HOUR, 
-            devclass=DEVICE_CLASS_ENERGY, icon=SOLAR_ICON, stateclass=STATE_CLASS_MEASUREMENT),
+            devclass=DEVICE_CLASS_ENERGY, icon=SOLAR_ICON, stateclass=STATE_CLASS_TOTAL_INCREASING),
     ]
 
     inverters = coordinator.data.get("inverters", {})


### PR DESCRIPTION
Fix for the energy dashboard thanks to @royvanmanen (issue #21 and #22)
Solves log entries: WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.ecu_lifetime_energy (<class 'custom_components.apsystems_ecur.sensor.APSystemsECUSensor'>) with state_class measurement has set last_reset. Setting last_reset for entities with state_class other than 'total' is deprecated and will be removed from Home Assistant Core 2021.11. Please update your configuration if state_class is manually configured, otherwise report it to the custom component author.