### PR TITLE
Removed `last_reset` property completely

### DIFF
--- a/custom_components/apsystems_ecur/sensor.py
+++ b/custom_components/apsystems_ecur/sensor.py
@@ -222,8 +222,6 @@ class APSystemsECUSensor(CoordinatorEntity, SensorEntity):
     @property
     def last_reset(self):
         #_LOGGER.debug(f"Last Reset - {self._field}")
-        if self._stateclass == STATE_CLASS_MEASUREMENT:
-            return dt_util.utc_from_timestamp(0)
         return None
 
     

--- a/custom_components/apsystems_ecur/sensor.py
+++ b/custom_components/apsystems_ecur/sensor.py
@@ -219,9 +219,3 @@ class APSystemsECUSensor(CoordinatorEntity, SensorEntity):
         #_LOGGER.debug(f"State class {self._stateclass} - {self._field}")
         return self._stateclass
 
-    @property
-    def last_reset(self):
-        #_LOGGER.debug(f"Last Reset - {self._field}")
-        return None
-
-    


### PR DESCRIPTION
sensor.ecu_current_power has a last_reset property set

This is deprecated and resulting in the following warning:

Entity sensor.ecu_current_power (<class 'custom_components.apsystems_ecur.sensor.APSystemsECUSensor'>) with state_class measurement has set last_reset. Setting last_reset for entities with state_class other than 'total' is deprecated and will be removed from Home Assistant Core 2021.11. Please update your configuration if state_class is manually configured, otherwise report it to the custom component author.