### PR TITLE
Change today_energy sensor stateclass back to TOTAL_INCREASING

### DIFF
--- a/custom_components/apsystems_ecur/sensor.py
+++ b/custom_components/apsystems_ecur/sensor.py
@@ -52,7 +52,7 @@ async def async_setup_entry(hass, config, add_entities, discovery_info=None):
             unit=UnitOfEnergy.KILO_WATT_HOUR,
             devclass=SensorDeviceClass.ENERGY,
             icon=SOLAR_ICON,
-            stateclass=SensorStateClass.TOTAL
+            stateclass=SensorStateClass.TOTAL_INCREASING
         ),
         APSystemsECUSensor(coordinator, ecu, "lifetime_energy", 
             label="Lifetime Energy",


### PR DESCRIPTION
According to the [HA docs](https://developers.home-assistant.io/docs/core/entity/sensor/) and the errors seen in issue #174 :

_Similar to total, with the restriction that the state represents a monotonically increasing positive total which periodically restarts counting from 0, e.g. a daily amount of consumed gas, weekly water consumption or lifetime energy consumption._

Seems to be the correct stateclass to use. This commit to change this back from TOTAL to TOTAL_INCREASING.