### PR TITLE
fix: inverter data should not be present in ecu

### DIFF
--- a/custom_components/apsystems_ecur/APSystemsSocket.py
+++ b/custom_components/apsystems_ecur/APSystemsSocket.py
@@ -292,13 +292,13 @@ class APSystemsSocket:
                             voltages.append(self.aps_int(data, cnt2 + 15))
                             power.append(self.aps_int(data, cnt2 + 17))
                             voltages.append(self.aps_int(data, cnt2 + 19))
-                            output = {
+                            inv_details = {
                             "model" : "YC600/DS3/DS3D-L",
                             "channel_qty" : 2,
                             "power" : power,
                             "voltage" : voltages
                             }
-                            inv.update(output)
+                            inv.update(inv_details)
                             cnt2 = cnt2 + 21
                         elif istr == '02':
                             power = []
@@ -313,13 +313,13 @@ class APSystemsSocket:
                             power.append(self.aps_int(data, cnt2 + 21))
                             voltages.append(self.aps_int(data, cnt2 + 23))
                             power.append(self.aps_int(data, cnt2 + 25))
-                            output = {
+                            inv_details = {
                             "model" : "YC1000/QT2",
                             "channel_qty" : 4,
                             "power" : power,
                             "voltage" : voltages
                             }
-                            inv.update(output)
+                            inv.update(inv_details)
                             cnt2 = cnt2 + 27
                         elif istr == '03':
                             power = []
@@ -332,13 +332,13 @@ class APSystemsSocket:
                             power.append(self.aps_int(data, cnt2 + 17))
                             power.append(self.aps_int(data, cnt2 + 19))
                             power.append(self.aps_int(data, cnt2 + 21))
-                            output = {
+                            inv_details = {
                             "model" : "QS1",
                             "channel_qty" : 4,
                             "power" : power,
                             "voltage" : voltages
                             }
-                            inv.update(output)
+                            inv.update(inv_details)
                             cnt2 = cnt2 + 23
                         else:
                             cnt2 = cnt2 + 9


### PR DESCRIPTION
Hi,
I was looking at the output of the ecu update and it looks like some inverter data are pushed at the ecu level and the ecu fields  "timestamp" and "inverter_qty" are missing.
It happens because the var "output" is also used and override in the inverter process