### PR TITLE
Added ability to remove a device

### DIFF
--- a/custom_components/apsystems_ecur/__init__.py
+++ b/custom_components/apsystems_ecur/__init__.py
@@ -199,7 +199,7 @@ async def async_remove_config_entry_device(hass, config, device_entry) -> bool:
     if device_entry is not None:
         # Notify the user that the device has been removed
         hass.components.persistent_notification.async_create(
-            f"The device {device_entry} has been removed from the system.",
+            f"The following device was removed from the system: {device_entry}",
             title="Device Removed",
         )
         return True

--- a/custom_components/apsystems_ecur/__init__.py
+++ b/custom_components/apsystems_ecur/__init__.py
@@ -195,6 +195,10 @@ async def async_setup_entry(hass, config):
     config.async_on_unload(config.add_update_listener(update_listener))
     return True
 
+async def async_remove_config_entry_device(hass, config, device_entry) -> bool:
+    _LOGGER.warning (f"The following device was removed: {device_entry}")
+    return True
+
 async def async_unload_entry(hass, config):
     unload_ok = await hass.config_entries.async_unload_platforms(config, PLATFORMS)
     coordinator = hass.data[DOMAIN].get("coordinator")

--- a/custom_components/apsystems_ecur/__init__.py
+++ b/custom_components/apsystems_ecur/__init__.py
@@ -196,8 +196,15 @@ async def async_setup_entry(hass, config):
     return True
 
 async def async_remove_config_entry_device(hass, config, device_entry) -> bool:
-    _LOGGER.warning (f"The following device was removed: {device_entry}")
-    return True
+    if device_entry is not None:
+        # Notify the user that the device has been removed
+        hass.components.persistent_notification.async_create(
+            f"The device {device_entry} has been removed from the system.",
+            title="Device Removed",
+        )
+        return True
+    else:
+        return False
 
 async def async_unload_entry(hass, config):
     unload_ok = await hass.config_entries.async_unload_platforms(config, PLATFORMS)


### PR DESCRIPTION
If an inverter fails and it is replaced, the old inverter can now be easily removed from the Device info card. The device is removed from the core.device_registry and placed under the "deleted devices" category.