### PR TITLE
Added feature to shut down inverters

### DIFF
--- a/custom_components/apsystems_ecur/__init__.py
+++ b/custom_components/apsystems_ecur/__init__.py
@@ -102,7 +102,6 @@ class ECUR():
 
     def update(self):
         data = {}
-        _LOGGER.warning(f"Inverters online: {self.inverters_online}")
         # if we aren't actively quering data, pull data form the cache
         # this is so we can stop querying after sunset
         if not self.querying:

--- a/custom_components/apsystems_ecur/__init__.py
+++ b/custom_components/apsystems_ecur/__init__.py
@@ -54,21 +54,20 @@ class ECUR():
         url = 'http://'+ str(WiFiSet.ipaddr) + '/index.php/configuration/set_switch_all_off'
         try:
             get_url = requests.post(url, headers=headers)
-            _LOGGER.warning(f"Response from ECU on switching the inverters off: {str(get_url.status_code)}")
+            self.inverters_online = False
+            _LOGGER.debug(f"Response from ECU on switching the inverters off: {str(get_url.status_code)}")
         except Exception as err:
             _LOGGER.warning(f"Attempt to switch inverters off failed with error: {err}")
-        self.inverters_online = False
 
     def inverters_on(self):
         headers = {'X-Requested-With': 'XMLHttpRequest'}
         url = 'http://'+ str(WiFiSet.ipaddr) + '/index.php/configuration/set_switch_all_on'
         try:
             get_url = requests.post(url, headers=headers)
-            _LOGGER.warning(f"Response from ECU on switching the inverters on: {str(get_url.status_code)}")
+            self.inverters_online = True
+            _LOGGER.debug(f"Response from ECU on switching the inverters on: {str(get_url.status_code)}")
         except Exception as err:
             _LOGGER.warning(f"Attempt to switch inverters on failed with error: {err}")
-        self.inverters_online = True
-
 
     def use_cached_data(self, msg):
         # we got invalid data, so we need to pull from cache

--- a/custom_components/apsystems_ecur/__init__.py
+++ b/custom_components/apsystems_ecur/__init__.py
@@ -50,10 +50,25 @@ class ECUR():
         self.querying = True
         
     def inverters_off(self):
+        headers = {'X-Requested-With': 'XMLHttpRequest'}
+        url = 'http://'+ str(WiFiSet.ipaddr) + '/index.php/configuration/set_switch_all_off'
+        try:
+            get_url = requests.post(url, headers=headers)
+            _LOGGER.warning(f"Response from ECU on switching the inverters off: {str(get_url.status_code)}")
+        except Exception as err:
+            _LOGGER.warning(f"Attempt to switch inverters off failed with error: {err}")
         self.inverters_online = False
 
     def inverters_on(self):
+        headers = {'X-Requested-With': 'XMLHttpRequest'}
+        url = 'http://'+ str(WiFiSet.ipaddr) + '/index.php/configuration/set_switch_all_on'
+        try:
+            get_url = requests.post(url, headers=headers)
+            _LOGGER.warning(f"Response from ECU on switching the inverters on: {str(get_url.status_code)}")
+        except Exception as err:
+            _LOGGER.warning(f"Attempt to switch inverters on failed with error: {err}")
         self.inverters_online = True
+
 
     def use_cached_data(self, msg):
         # we got invalid data, so we need to pull from cache
@@ -89,26 +104,6 @@ class ECUR():
     def update(self):
         data = {}
         _LOGGER.warning(f"Inverters online: {self.inverters_online}")
-        if self.inverters_online == False:
-            self.querying = False
-            headers = {'X-Requested-With': 'XMLHttpRequest'}
-            url = 'http://'+ str(WiFiSet.ipaddr) + '/index.php/configuration/set_switch_all_off'
-            try:
-                get_url = requests.post(url, headers=headers)
-                _LOGGER.warning(f"Response from ECU on switching the inverters off: {str(get_url.status_code)}")
-            except Exception as err:
-                _LOGGER.warning(f"Attempt to switch inverters off failed with error: {err}")
-        else:
-            if self.querying == False:
-                self.querying = True
-                headers = {'X-Requested-With': 'XMLHttpRequest'}
-                url = 'http://'+ str(WiFiSet.ipaddr) + '/index.php/configuration/set_switch_all_on'
-                try:
-                    get_url = requests.post(url, headers=headers)
-                    _LOGGER.warning(f"Response from ECU on switching the inverters on: {str(get_url.status_code)}")
-                except Exception as err:
-                    _LOGGER.warning(f"Attempt to switch inverters on failed with error: {err}")
-
         # if we aren't actively quering data, pull data form the cache
         # this is so we can stop querying after sunset
         if not self.querying:

--- a/custom_components/apsystems_ecur/__init__.py
+++ b/custom_components/apsystems_ecur/__init__.py
@@ -35,6 +35,7 @@ class ECUR():
         self.cache_count = 0
         self.data_from_cache = False
         self.querying = True
+        self.inverters_online = True
         self.ecu_restarting = False
         self.cached_data = {}
         WiFiSet.ipaddr = ipaddr
@@ -47,6 +48,12 @@ class ECUR():
 
     def start_query(self):
         self.querying = True
+        
+    def inverters_off(self):
+        self.inverters_online = False
+
+    def inverters_on(self):
+        self.inverters_online = True
 
     def use_cached_data(self, msg):
         # we got invalid data, so we need to pull from cache
@@ -64,7 +71,7 @@ class ECUR():
                 headers = {'X-Requested-With': 'XMLHttpRequest'}
                 try:
                     get_url = requests.post(url, headers=headers, data=data)
-                    _LOGGER.debug(f"Response from ECU on restart: {str(get_url.status_code)}.")
+                    _LOGGER.debug(f"Response from ECU on restart: {str(get_url.status_code)}")
                     self.ecu_restarting = True
                 except Exception as err:
                     _LOGGER.warning(f"Attempt to restart ECU failed with error: {err}. Querying is stopped automatically.")
@@ -81,6 +88,27 @@ class ECUR():
 
     def update(self):
         data = {}
+        _LOGGER.warning(f"Inverters online: {self.inverters_online}")
+        if self.inverters_online == False:
+            self.querying = False
+            headers = {'X-Requested-With': 'XMLHttpRequest'}
+            url = 'http://'+ str(WiFiSet.ipaddr) + '/index.php/configuration/set_switch_all_off'
+            try:
+                get_url = requests.post(url, headers=headers)
+                _LOGGER.warning(f"Response from ECU on switching the inverters off: {str(get_url.status_code)}")
+            except Exception as err:
+                _LOGGER.warning(f"Attempt to switch inverters off failed with error: {err}")
+        else:
+            if self.querying == False:
+                self.querying = True
+                headers = {'X-Requested-With': 'XMLHttpRequest'}
+                url = 'http://'+ str(WiFiSet.ipaddr) + '/index.php/configuration/set_switch_all_on'
+                try:
+                    get_url = requests.post(url, headers=headers)
+                    _LOGGER.warning(f"Response from ECU on switching the inverters on: {str(get_url.status_code)}")
+                except Exception as err:
+                    _LOGGER.warning(f"Attempt to switch inverters on failed with error: {err}")
+
         # if we aren't actively quering data, pull data form the cache
         # this is so we can stop querying after sunset
         if not self.querying:

--- a/custom_components/apsystems_ecur/const.py
+++ b/custom_components/apsystems_ecur/const.py
@@ -5,6 +5,7 @@ SIGNAL_ICON = "mdi:signal"
 RELOAD_ICON = "mdi:reload"
 CACHE_ICON = "mdi:cached"
 RESTART_ICON = "mdi:restart"
+POWER_ICON = "mdi:power"
 
 CONF_SSID = "SSID"
 CONF_WPA_PSK = "WPA-PSK"

--- a/custom_components/apsystems_ecur/switch.py
+++ b/custom_components/apsystems_ecur/switch.py
@@ -19,7 +19,6 @@ async def async_setup_entry(hass, config, add_entities, discovery_info=None):
 
     ecu = hass.data[DOMAIN].get("ecu")
     coordinator = hass.data[DOMAIN].get("coordinator")
-
     switches = [
         APSystemsECUQuerySwitch(coordinator, ecu, "query_device", 
             label="Query Device", icon=RELOAD_ICON),
@@ -28,13 +27,9 @@ async def async_setup_entry(hass, config, add_entities, discovery_info=None):
     ]
     add_entities(switches)
 
-
 class APSystemsECUQuerySwitch(CoordinatorEntity, SwitchEntity):
-
     def __init__(self, coordinator, ecu, field, label=None, icon=None):
-
         super().__init__(coordinator)
-
         self.coordinator = coordinator
         self._ecu = ecu
         self._field = field
@@ -42,7 +37,6 @@ class APSystemsECUQuerySwitch(CoordinatorEntity, SwitchEntity):
         if not label:
             self._label = field
         self._icon = icon
-
         self._name = f"ECU {self._label}"
         self._state = True
 
@@ -86,11 +80,8 @@ class APSystemsECUQuerySwitch(CoordinatorEntity, SwitchEntity):
         self.schedule_update_ha_state()
 
 class APSystemsECUInvertersSwitch(CoordinatorEntity, SwitchEntity):
-
     def __init__(self, coordinator, ecu, field, label=None, icon=None):
-
         super().__init__(coordinator)
-
         self.coordinator = coordinator
         self._ecu = ecu
         self._field = field
@@ -98,7 +89,6 @@ class APSystemsECUInvertersSwitch(CoordinatorEntity, SwitchEntity):
         if not label:
             self._label = field
         self._icon = icon
-
         self._name = f"ECU {self._label}"
         self._state = True
 
@@ -140,4 +130,3 @@ class APSystemsECUInvertersSwitch(CoordinatorEntity, SwitchEntity):
         self._ecu.inverters_on()
         self._state = True
         self.schedule_update_ha_state()
-

--- a/custom_components/apsystems_ecur/switch.py
+++ b/custom_components/apsystems_ecur/switch.py
@@ -9,7 +9,8 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import (
     DOMAIN,
-    RELOAD_ICON
+    RELOAD_ICON,
+    POWER_ICON
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,6 +23,8 @@ async def async_setup_entry(hass, config, add_entities, discovery_info=None):
     switches = [
         APSystemsECUQuerySwitch(coordinator, ecu, "query_device", 
             label="Query Device", icon=RELOAD_ICON),
+        APSystemsECUInvertersSwitch(coordinator, ecu, "inverters_online", 
+            label="Inverters Online", icon=POWER_ICON),
     ]
     add_entities(switches)
 
@@ -81,3 +84,60 @@ class APSystemsECUQuerySwitch(CoordinatorEntity, SwitchEntity):
         self._ecu.start_query()
         self._state = True
         self.schedule_update_ha_state()
+
+class APSystemsECUInvertersSwitch(CoordinatorEntity, SwitchEntity):
+
+    def __init__(self, coordinator, ecu, field, label=None, icon=None):
+
+        super().__init__(coordinator)
+
+        self.coordinator = coordinator
+        self._ecu = ecu
+        self._field = field
+        self._label = label
+        if not label:
+            self._label = field
+        self._icon = icon
+
+        self._name = f"ECU {self._label}"
+        self._state = True
+
+    @property
+    def unique_id(self):
+        return f"{self._ecu.ecu.ecu_id}_{self._field}"
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def icon(self):
+        return self._icon
+
+    @property
+    def device_info(self):
+        parent = f"ecu_{self._ecu.ecu.ecu_id}"
+        return {
+            "identifiers": {
+                (DOMAIN, parent),
+            }
+        }
+
+    @property
+    def entity_category(self):
+        return EntityCategory.CONFIG
+    
+    @property
+    def is_on(self):
+        return self._ecu.inverters_online
+
+    def turn_off(self, **kwargs):
+        self._ecu.inverters_off()
+        self._state = False
+        self.schedule_update_ha_state()
+    
+    def turn_on(self, **kwargs):
+        self._ecu.inverters_on()
+        self._state = True
+        self.schedule_update_ha_state()
+


### PR DESCRIPTION
With an added switch entity, you are now able to shut down inverters. This only works on ECU-C and ECU-R pro type ECU's.  For older ECU-R models starting with ECU-id 2160 the switch does not work unfortunately. 
![image](https://github.com/ksheumaker/homeassistant-apsystems_ecur/assets/82239374/49a4b291-40ce-43a7-81dd-cb6bcaf918a2)

The switch enables you to create an automation which switches of the inverters when electricity prices become negative and turn them back on when positive again.

Thanks go to @harryboer for testing and providing information