### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/apsystems_ecur/__init__.py
+++ b/custom_components/apsystems_ecur/__init__.py
@@ -12,7 +12,9 @@ from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.entity import Entity
 from homeassistant import config_entries, exceptions
 from homeassistant.helpers import device_registry as dr
-from homeassistant.components.persistent_notification import async_create
+from homeassistant.components.persistent_notification import (
+    create as create_persistent_notification
+    )
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -220,10 +222,10 @@ async def async_setup_entry(hass, config):
 async def async_remove_config_entry_device(hass, config, device_entry) -> bool:
     if device_entry is not None:
         # Notify the user that the device has been removed
-        async_create(
+        create_persistent_notification(
             hass,
-            title='Important notification',
-            message=f'The following device was removed from the system: {device_entry}'
+            title="Important notification",
+            message=f"The following device was removed from the system: {device_entry}"
         )
         return True
     else:

--- a/custom_components/apsystems_ecur/__init__.py
+++ b/custom_components/apsystems_ecur/__init__.py
@@ -12,12 +12,14 @@ from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.entity import Entity
 from homeassistant import config_entries, exceptions
 from homeassistant.helpers import device_registry as dr
+from homeassistant.components.persistent_notification import async_create
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
     UpdateFailed,
     )
 from .const import DOMAIN
+
 _LOGGER = logging.getLogger(__name__)
 PLATFORMS = [ "sensor", "binary_sensor", "switch" ]
 

--- a/custom_components/apsystems_ecur/__init__.py
+++ b/custom_components/apsystems_ecur/__init__.py
@@ -222,8 +222,8 @@ async def async_remove_config_entry_device(hass, config, device_entry) -> bool:
         # Notify the user that the device has been removed
         async_create(
             hass,
-            f"The following device was removed from the system: {device_entry}",
-            title='Important notification'
+            title='Important notification',
+            message= f'The following device was removed from the system: {device_entry}'
         )
         return True
     else:

--- a/custom_components/apsystems_ecur/__init__.py
+++ b/custom_components/apsystems_ecur/__init__.py
@@ -223,7 +223,7 @@ async def async_remove_config_entry_device(hass, config, device_entry) -> bool:
         async_create(
             hass,
             title='Important notification',
-            message= f'The following device was removed from the system: {device_entry}'
+            message=f'The following device was removed from the system: {device_entry}'
         )
         return True
     else:

--- a/custom_components/apsystems_ecur/__init__.py
+++ b/custom_components/apsystems_ecur/__init__.py
@@ -218,9 +218,10 @@ async def async_setup_entry(hass, config):
 async def async_remove_config_entry_device(hass, config, device_entry) -> bool:
     if device_entry is not None:
         # Notify the user that the device has been removed
-        hass.components.persistent_notification.async_create(
+        async_create(
+            hass,
             f"The following device was removed from the system: {device_entry}",
-            title="Device Removed",
+            title='Important notification'
         )
         return True
     else:


### PR DESCRIPTION
Replaced deprecated hass.components.persistent_notification that will stop working in Home Assistant 2024.9 Updated to import functions used from persistent_notification directly.